### PR TITLE
Corrected passing of mmax parameter in multipole_electrostatics

### DIFF
--- a/src/ddx_multipolar_solutes.f90
+++ b/src/ddx_multipolar_solutes.f90
@@ -47,15 +47,15 @@ subroutine multipole_electrostatics(params, constants, workspace, multipoles, &
     if (electrostatics % do_phi .and. electrostatics % do_e &
             & .and. electrostatics % do_g) then
         call multipole_electrostatics_2(params, constants, workspace, &
-            & multipoles, 0, electrostatics % phi_cav, &
+            & multipoles, mmax, electrostatics % phi_cav, &
             & electrostatics % e_cav, electrostatics % g_cav, ddx_error)
     else if (electrostatics % do_phi .and. electrostatics % do_e) then
         call multipole_electrostatics_1(params, constants, workspace, &
-            & multipoles, 0, electrostatics % phi_cav, &
+            & multipoles, mmax, electrostatics % phi_cav, &
             & electrostatics % e_cav, ddx_error)
     else
         call multipole_electrostatics_0(params, constants, workspace, &
-            & multipoles, 0, electrostatics % phi_cav, ddx_error)
+            & multipoles, mmax, electrostatics % phi_cav, ddx_error)
     end if
 
 end subroutine multipole_electrostatics


### PR DESCRIPTION
I am currently working on using **ddX** together with a **multipole-expanded solute density**. While implementing this, I noticed that in `multipole_electrostatics` the argument `mmax` is strictly passed as `mmax=0` to its subsequent subroutines. This prevents setting up a suitable potential beyond monopoles.

I corrected the corresponding arguments to use the more general `mmax`, which should already be defined when the host code calls the function. I suppose this was the original intention, since other routines in the `ddx_multipolar_solutes` module pass `mmax` as well. The routines `multipole_electrostatics_1`–`multipole_electrostatics_3` likewise expect `mmax` as an argument and do not need to be restricted to 0.

This should therefore be a straightforward bug fix and is not expected to introduce further issues.